### PR TITLE
feat: 해시태그 구현, 테이블 분리, 모아보기 기능 구현

### DIFF
--- a/src/main/java/com/goormthon/rememberspring/diary/api/controller/DiaryController.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/api/controller/DiaryController.java
@@ -2,7 +2,7 @@ package com.goormthon.rememberspring.diary.api.controller;
 
 import com.goormthon.rememberspring.diary.api.dto.request.DiaryContentRequestDto;
 import com.goormthon.rememberspring.diary.api.dto.response.DiaryResponseDto;
-import com.goormthon.rememberspring.diary.application.DiaryService;
+import com.goormthon.rememberspring.diary.application.DiaryGeneratorService;
 import com.goormthon.rememberspring.global.template.RspTemplate;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class DiaryController {
 
     @Autowired
-    private DiaryService diaryService;
+    private DiaryGeneratorService diaryGeneratorService;
 
     @Operation(summary = "일기 생성", description = "일기를 생성합니다.")
     @ApiResponses(value = {
@@ -37,7 +37,7 @@ public class DiaryController {
         return new RspTemplate<>(
                 HttpStatus.OK,
                 "일기 생성",
-                diaryService.chat(email, diaryContentRequestDto)
+                diaryGeneratorService.chat(email, diaryContentRequestDto)
                 );
     }
 
@@ -51,7 +51,7 @@ public class DiaryController {
         return new RspTemplate<>(
                 HttpStatus.OK,
                 "일기 생성",
-                diaryService.retry(email)
+                diaryGeneratorService.retry(email)
         );
     }
 

--- a/src/main/java/com/goormthon/rememberspring/diary/api/controller/DiaryController.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/api/controller/DiaryController.java
@@ -1,23 +1,20 @@
 package com.goormthon.rememberspring.diary.api.controller;
 
 import com.goormthon.rememberspring.diary.api.dto.request.DiaryContentRequestDto;
-import com.goormthon.rememberspring.diary.api.dto.response.ChatGptResponseDto;
-import com.goormthon.rememberspring.diary.api.dto.response.DiaryContentResponseDto;
 import com.goormthon.rememberspring.diary.api.dto.response.DiaryResponseDto;
 import com.goormthon.rememberspring.diary.application.DiaryService;
-import com.goormthon.rememberspring.diary.domain.entity.Diary;
 import com.goormthon.rememberspring.global.template.RspTemplate;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/user")
@@ -50,12 +47,11 @@ public class DiaryController {
     })
     @PostMapping(value = "/retry")
     public RspTemplate<DiaryResponseDto> retryDiary(
-            @AuthenticationPrincipal String email,
-            @RequestParam Long diaryId) throws Exception{
+            @AuthenticationPrincipal String email) throws Exception{
         return new RspTemplate<>(
                 HttpStatus.OK,
                 "일기 생성",
-                diaryService.retry(email, diaryId)
+                diaryService.retry(email)
         );
     }
 

--- a/src/main/java/com/goormthon/rememberspring/diary/api/controller/DiaryController.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/api/controller/DiaryController.java
@@ -3,17 +3,26 @@ package com.goormthon.rememberspring.diary.api.controller;
 import com.goormthon.rememberspring.diary.api.dto.request.DiaryContentRequestDto;
 import com.goormthon.rememberspring.diary.api.dto.response.DiaryResponseDto;
 import com.goormthon.rememberspring.diary.application.DiaryGeneratorService;
+import com.goormthon.rememberspring.diary.application.DiaryService;
+import com.goormthon.rememberspring.diary.domain.entity.Diary;
 import com.goormthon.rememberspring.global.template.RspTemplate;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,8 +30,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class DiaryController {
 
-    @Autowired
-    private DiaryGeneratorService diaryGeneratorService;
+    private final DiaryGeneratorService diaryGeneratorService;
+    private final DiaryService diaryService;
 
     @Operation(summary = "일기 생성", description = "일기를 생성합니다.")
     @ApiResponses(value = {
@@ -47,12 +56,28 @@ public class DiaryController {
     })
     @PostMapping(value = "/retry")
     public RspTemplate<DiaryResponseDto> retryDiary(
-            @AuthenticationPrincipal String email) throws Exception{
+            @AuthenticationPrincipal String email,
+            @RequestParam(name = "diary") Long diaryId) throws Exception{
         return new RspTemplate<>(
                 HttpStatus.OK,
                 "일기 생성",
-                diaryGeneratorService.retry(email)
+                diaryGeneratorService.retry(email, diaryId)
         );
+    }
+
+    @Operation(summary = "모아보기", description = "나의 다이어리를 모두 불러옵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증실패", content = @Content(schema = @Schema(example = "INVALID_HEADER or INVALID_TOKEN"))),
+    })
+    @GetMapping("/diaries/{filter}")
+    public RspTemplate<List<Diary>> findAllDiaries(@AuthenticationPrincipal String email,
+                                                   @Parameter(name = "filter", description = "다이어리 모아보기(ex. 모아서, 순서)", in = ParameterIn.PATH)
+                                                   @PathVariable(name = "filter") String filter,
+                                                   @RequestParam(value = "page", defaultValue = "0") int page,
+                                                   @RequestParam(value = "size", defaultValue = "10") int size) {
+        List<Diary> allDiaries = diaryService.findAllDiaries(email, filter, page, size);
+        return new RspTemplate<>(HttpStatus.OK, "조회", allDiaries);
     }
 
 }

--- a/src/main/java/com/goormthon/rememberspring/diary/api/controller/DiaryController.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/api/controller/DiaryController.java
@@ -16,9 +16,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -81,12 +78,11 @@ public class DiaryController {
                                                                   @RequestParam(value = "page", defaultValue = "0") int page,
                                                                   @RequestParam(value = "size", defaultValue = "10") int size) {
         List<HashtagDiariesResDto> allDiaries = new ArrayList<>();
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "diaryId"));
 
         if (filterIndex == 1) {
             allDiaries = diaryService.gatherAllDiaries(email, page, size);
         } else {
-
+            allDiaries = diaryService.orderAllDiaries(email, page, size);
         }
 
         return new RspTemplate<>(HttpStatus.OK, "조회", allDiaries);

--- a/src/main/java/com/goormthon/rememberspring/diary/api/controller/DiaryController.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/api/controller/DiaryController.java
@@ -1,10 +1,10 @@
 package com.goormthon.rememberspring.diary.api.controller;
 
 import com.goormthon.rememberspring.diary.api.dto.request.DiaryContentRequestDto;
-import com.goormthon.rememberspring.diary.api.dto.response.DiaryResponseDto;
+import com.goormthon.rememberspring.diary.api.dto.response.DiaryGeneratorResponseDto;
+import com.goormthon.rememberspring.diary.api.dto.response.HashtagDiariesResDto;
 import com.goormthon.rememberspring.diary.application.DiaryGeneratorService;
 import com.goormthon.rememberspring.diary.application.DiaryService;
-import com.goormthon.rememberspring.diary.domain.entity.Diary;
 import com.goormthon.rememberspring.global.template.RspTemplate;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -13,8 +13,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,7 +42,7 @@ public class DiaryController {
             @ApiResponse(responseCode = "200", description = "일기 생성 성공"),
     })
     @PostMapping(value = "/create")
-    public RspTemplate<DiaryResponseDto> createDiary(
+    public RspTemplate<DiaryGeneratorResponseDto> createDiary(
             @AuthenticationPrincipal String email,
             @RequestBody DiaryContentRequestDto diaryContentRequestDto) throws Exception{
 
@@ -55,7 +59,7 @@ public class DiaryController {
             @ApiResponse(responseCode = "200", description = "일기 생성 재요청 성공"),
     })
     @PostMapping(value = "/retry")
-    public RspTemplate<DiaryResponseDto> retryDiary(
+    public RspTemplate<DiaryGeneratorResponseDto> retryDiary(
             @AuthenticationPrincipal String email,
             @RequestParam(name = "diary") Long diaryId) throws Exception{
         return new RspTemplate<>(
@@ -70,13 +74,21 @@ public class DiaryController {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증실패", content = @Content(schema = @Schema(example = "INVALID_HEADER or INVALID_TOKEN"))),
     })
-    @GetMapping("/diaries/{filter}")
-    public RspTemplate<List<Diary>> findAllDiaries(@AuthenticationPrincipal String email,
-                                                   @Parameter(name = "filter", description = "다이어리 모아보기(ex. 모아서, 순서)", in = ParameterIn.PATH)
-                                                   @PathVariable(name = "filter") String filter,
-                                                   @RequestParam(value = "page", defaultValue = "0") int page,
-                                                   @RequestParam(value = "size", defaultValue = "10") int size) {
-        List<Diary> allDiaries = diaryService.findAllDiaries(email, filter, page, size);
+    @GetMapping("/diaries/{filterIndex}")
+    public RspTemplate<List<HashtagDiariesResDto>> findAllDiaries(@AuthenticationPrincipal String email,
+                                                                  @Parameter(name = "filterIndex", description = "다이어리 모아보기(ex. 1: 모아서, 2: 순서)", in = ParameterIn.PATH)
+                                                                  @PathVariable(name = "filterIndex") int filterIndex,
+                                                                  @RequestParam(value = "page", defaultValue = "0") int page,
+                                                                  @RequestParam(value = "size", defaultValue = "10") int size) {
+        List<HashtagDiariesResDto> allDiaries = new ArrayList<>();
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "diaryId"));
+
+        if (filterIndex == 1) {
+            allDiaries = diaryService.gatherAllDiaries(email, page, size);
+        } else {
+
+        }
+
         return new RspTemplate<>(HttpStatus.OK, "조회", allDiaries);
     }
 

--- a/src/main/java/com/goormthon/rememberspring/diary/api/dto/request/ChatGptRequestDto.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/api/dto/request/ChatGptRequestDto.java
@@ -1,17 +1,21 @@
 package com.goormthon.rememberspring.diary.api.dto.request;
 
 import com.goormthon.rememberspring.diary.api.dto.Message;
-import lombok.Data;
-
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Data
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatGptRequestDto {
     private String model;
     private List<Message> messages;
 
-    public ChatGptRequestDto(String model, String prompt) {
+    @Builder
+    private ChatGptRequestDto(String model, String prompt) {
         this.model = model;
         this.messages =  new ArrayList<>();
         this.messages.add(new Message("user", prompt));

--- a/src/main/java/com/goormthon/rememberspring/diary/api/dto/response/DiaryContentResponseDto.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/api/dto/response/DiaryContentResponseDto.java
@@ -1,14 +1,17 @@
 package com.goormthon.rememberspring.diary.api.dto.response;
 
+import java.util.List;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import java.util.List;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DiaryContentResponseDto {
     private String title;
     private String date;
-    private List<String> hashTag;
+    private List<String> hashtag;
     private String contents;
 }

--- a/src/main/java/com/goormthon/rememberspring/diary/api/dto/response/DiaryGeneratorResponseDto.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/api/dto/response/DiaryGeneratorResponseDto.java
@@ -6,19 +6,19 @@ import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record DiaryResponseDto (
+public record DiaryGeneratorResponseDto(
         Long diaryId,
         String title,
         String content,
         List<String> hashtags,
         List<ImageResDto> images
 ) {
-    public static DiaryResponseDto from(Diary diary, List<ImageResDto> imageResDto) {
+    public static DiaryGeneratorResponseDto from(Diary diary, List<ImageResDto> imageResDto) {
         List<String> hashtags = diary.getDiaryHashtagMapping().stream()
                 .map(diaryHashtagMapping -> diaryHashtagMapping.getHashtag().getName())
                 .toList();
 
-        return DiaryResponseDto.builder()
+        return DiaryGeneratorResponseDto.builder()
                 .diaryId(diary.getDiaryId())
                 .title(diary.getTitle())
                 .content(diary.getContent())

--- a/src/main/java/com/goormthon/rememberspring/diary/api/dto/response/DiaryResDto.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/api/dto/response/DiaryResDto.java
@@ -1,0 +1,38 @@
+package com.goormthon.rememberspring.diary.api.dto.response;
+
+import com.goormthon.rememberspring.diary.domain.entity.Diary;
+import com.goormthon.rememberspring.image.api.dto.response.ImageResDto;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record DiaryResDto(
+        Long diaryId,
+        boolean isPublic,
+        String title,
+        String createAt,
+        String content,
+        List<String> hashtags,
+        List<ImageResDto> imageResDtoList
+) {
+    public static DiaryResDto from(Diary diary) {
+        List<String> hashtags = diary.getDiaryHashtagMapping().stream()
+                .map(diaryHashtagMapping -> diaryHashtagMapping.getHashtag().getName())
+                .toList();
+
+        List<ImageResDto> imageResDtos = diary.getImages().stream()
+                .map(ImageResDto::from)
+                .toList();
+
+        return DiaryResDto.builder()
+                .diaryId(diary.getDiaryId())
+                .isPublic(diary.isPublic())
+                .title(diary.getTitle())
+                .createAt(diary.getCreateAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")))
+                .content(diary.getContent())
+                .hashtags(hashtags)
+                .imageResDtoList(imageResDtos)
+                .build();
+    }
+}

--- a/src/main/java/com/goormthon/rememberspring/diary/api/dto/response/DiaryResponseDto.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/api/dto/response/DiaryResponseDto.java
@@ -2,25 +2,27 @@ package com.goormthon.rememberspring.diary.api.dto.response;
 
 import com.goormthon.rememberspring.diary.domain.entity.Diary;
 import com.goormthon.rememberspring.image.api.dto.response.ImageResDto;
-import com.goormthon.rememberspring.member.domain.Member;
-import lombok.Builder;
-
 import java.util.List;
+import lombok.Builder;
 
 @Builder
 public record DiaryResponseDto (
         Long diaryId,
         String title,
         String content,
-        List<String> hashTags,
+        List<String> hashtags,
         List<ImageResDto> images
 ) {
     public static DiaryResponseDto from(Diary diary, List<ImageResDto> imageResDto) {
+        List<String> hashtags = diary.getDiaryHashtagMapping().stream()
+                .map(diaryHashtagMapping -> diaryHashtagMapping.getHashtag().getName())
+                .toList();
+
         return DiaryResponseDto.builder()
                 .diaryId(diary.getDiaryId())
                 .title(diary.getTitle())
                 .content(diary.getContent())
-                .hashTags(diary.getHashTags())
+                .hashtags(hashtags)
                 .images(imageResDto)
                 .build();
     }

--- a/src/main/java/com/goormthon/rememberspring/diary/api/dto/response/HashtagDiariesResDto.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/api/dto/response/HashtagDiariesResDto.java
@@ -6,12 +6,18 @@ import org.springframework.data.domain.Page;
 @Builder
 public record HashtagDiariesResDto(
         String hashtagName,
-        Page<DiaryResDto> diaryResponseDtoList
+        Page<DiaryResDto> diaryResDtoList
 ) {
-    public static HashtagDiariesResDto of(String hashtagName, Page<DiaryResDto> diaryResponseDtoList) {
+    public static HashtagDiariesResDto of(String hashtagName, Page<DiaryResDto> diaryResDtoList) {
         return HashtagDiariesResDto.builder()
                 .hashtagName(hashtagName)
-                .diaryResponseDtoList(diaryResponseDtoList)
+                .diaryResDtoList(diaryResDtoList)
+                .build();
+    }
+
+    public static HashtagDiariesResDto from(Page<DiaryResDto> diaryResDtoList) {
+        return HashtagDiariesResDto.builder()
+                .diaryResDtoList(diaryResDtoList)
                 .build();
     }
 }

--- a/src/main/java/com/goormthon/rememberspring/diary/api/dto/response/HashtagDiariesResDto.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/api/dto/response/HashtagDiariesResDto.java
@@ -1,0 +1,17 @@
+package com.goormthon.rememberspring.diary.api.dto.response;
+
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+@Builder
+public record HashtagDiariesResDto(
+        String hashtagName,
+        Page<DiaryResDto> diaryResponseDtoList
+) {
+    public static HashtagDiariesResDto of(String hashtagName, Page<DiaryResDto> diaryResponseDtoList) {
+        return HashtagDiariesResDto.builder()
+                .hashtagName(hashtagName)
+                .diaryResponseDtoList(diaryResponseDtoList)
+                .build();
+    }
+}

--- a/src/main/java/com/goormthon/rememberspring/diary/application/DiaryGeneratorService.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/application/DiaryGeneratorService.java
@@ -6,7 +6,7 @@ import com.goormthon.rememberspring.diary.api.dto.request.ChatGptRequestDto;
 import com.goormthon.rememberspring.diary.api.dto.request.DiaryContentRequestDto;
 import com.goormthon.rememberspring.diary.api.dto.response.ChatGptResponseDto;
 import com.goormthon.rememberspring.diary.api.dto.response.DiaryContentResponseDto;
-import com.goormthon.rememberspring.diary.api.dto.response.DiaryResponseDto;
+import com.goormthon.rememberspring.diary.api.dto.response.DiaryGeneratorResponseDto;
 import com.goormthon.rememberspring.diary.domain.entity.Diary;
 import com.goormthon.rememberspring.diary.domain.entity.Hashtag;
 import com.goormthon.rememberspring.diary.domain.repository.DiaryHashtagRepository;
@@ -52,7 +52,7 @@ public class DiaryGeneratorService {
     private final DiaryHashtagRepository diaryHashtagRepository;
 
     @Transactional
-    public DiaryResponseDto chat(String email, DiaryContentRequestDto diaryContentRequestDto) throws Exception {
+    public DiaryGeneratorResponseDto chat(String email, DiaryContentRequestDto diaryContentRequestDto) throws Exception {
         // 인증 시, 헤더에 실려온 토큰을 분석하여 이메일을 받아와, Member 객체 받아옴.
         Member member = memberRepository.findByEmail(email).orElse(null);
         // 아직 일기 생성이 안되었으므로, 이미지 DB의 diary_id 컬럼은  null
@@ -101,11 +101,11 @@ public class DiaryGeneratorService {
             imageRepository.save(images);
         }
 
-        return DiaryResponseDto.from(diary, imageResDto);
+        return DiaryGeneratorResponseDto.from(diary, imageResDto);
     }
 
     @Transactional
-    public DiaryResponseDto retry(String email, Long diaryId) throws Exception {
+    public DiaryGeneratorResponseDto retry(String email, Long diaryId) throws Exception {
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Diary diary = diaryRepository.findById(diaryId).orElseThrow(DiaryNotFoundException::new);
         List<Image> getImages = imageRepository.findByDiaryAndMember(diary, member);
@@ -147,7 +147,7 @@ public class DiaryGeneratorService {
             }
         }
 
-        return DiaryResponseDto.from(diary, imageResDto);
+        return DiaryGeneratorResponseDto.from(diary, imageResDto);
     }
 
     private String buildQuery(ImageResDto imageFile, DiaryContentRequestDto dto) throws Exception {
@@ -185,7 +185,7 @@ public class DiaryGeneratorService {
 
     }
 
-    private static List<ImageResDto> getImageResDtos(List<Image> getImages) {
+    private List<ImageResDto> getImageResDtos(List<Image> getImages) {
         List<ImageResDto> imageResDto = new ArrayList<>();
 
         for (Image image : getImages) {

--- a/src/main/java/com/goormthon/rememberspring/diary/application/DiaryGeneratorService.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/application/DiaryGeneratorService.java
@@ -27,7 +27,7 @@ import org.springframework.web.client.RestTemplate;
 
 
 @Service
-public class DiaryService {
+public class DiaryGeneratorService {
 
     @Value("${spring.openai.model}")
     private String model;
@@ -42,7 +42,7 @@ public class DiaryService {
     private final MemberRepository memberRepository;
     private final DiaryRepository diaryRepository;
 
-    public DiaryService(ObjectMapper objectMapper, ImageRepository imageRepository, MemberRepository memberRepository, DiaryRepository diaryRepository) {
+    public DiaryGeneratorService(ObjectMapper objectMapper, ImageRepository imageRepository, MemberRepository memberRepository, DiaryRepository diaryRepository) {
         this.objectMapper = objectMapper;
         this.imageRepository = imageRepository;
         this.memberRepository = memberRepository;

--- a/src/main/java/com/goormthon/rememberspring/diary/application/DiaryService.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/application/DiaryService.java
@@ -1,0 +1,94 @@
+package com.goormthon.rememberspring.diary.application;
+
+import com.goormthon.rememberspring.diary.api.dto.response.DiaryResDto;
+import com.goormthon.rememberspring.diary.api.dto.response.HashtagDiariesResDto;
+import com.goormthon.rememberspring.diary.domain.entity.DiaryHashtagMapping;
+import com.goormthon.rememberspring.diary.domain.repository.DiaryHashtagRepository;
+import com.goormthon.rememberspring.diary.domain.repository.DiaryRepository;
+import com.goormthon.rememberspring.member.domain.Member;
+import com.goormthon.rememberspring.member.domain.repository.MemberRepository;
+import com.goormthon.rememberspring.member.exception.MemberNotFoundException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DiaryService {
+
+    private final DiaryRepository diaryRepository;
+    private final MemberRepository memberRepository;
+    private final DiaryHashtagRepository diaryHashtagRepository;
+
+    // 모아서 보기
+    public List<HashtagDiariesResDto> gatherAllDiaries(String email, int page, int size) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        List<HashtagDiariesResDto> hashtagDiariesResDtoList = new ArrayList<>();
+
+        // 월에 대한 유저의 일기
+        hashtagDiariesResDtoList.add(HashtagDiariesResDto.of(
+                String.format("%d월의 일기", getMonth()),
+                getMonthDiaries(member, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "diaryId"))))
+        );
+
+        // 멤버가 가지고 있는 다이어리에서 유니크 해시태그 가져오기.
+        List<DiaryHashtagMapping> memberDiaryHashtagMapping = diaryHashtagRepository.findAllByMemberDiaryHashtag(member);
+        List<String> uniqueHashtags = getUniqueHashtags(memberDiaryHashtagMapping);
+
+        for (String hashtagName : uniqueHashtags) {
+            // 멤버가 가지고 있는 다이어리와 매핑된 해시태그를 가져온다.
+            Page<DiaryHashtagMapping> diaryHashtagMappings = diaryHashtagRepository.findByDiary_MemberAndHashtag_Name(
+                    member,
+                    hashtagName,
+                    PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"))
+            );
+            Page<DiaryResDto> diaryResDtos = getDiaryResDtos(diaryHashtagMappings);
+
+            hashtagDiariesResDtoList.add(HashtagDiariesResDto.of(hashtagName, diaryResDtos));
+        }
+
+        return hashtagDiariesResDtoList;
+    }
+
+    // 월간 다이어리
+    private Page<DiaryResDto> getMonthDiaries(Member member, Pageable pageable) {
+        return diaryRepository.findByMonth(member, getMonth(), pageable);
+    }
+
+    private int getMonth() {
+        return LocalDate.now().getMonth().getValue();
+    }
+
+    // 나의 다이어리와 연결되어 있는 해시태그 이름을 가져온다.
+    private List<String> getUniqueHashtags(List<DiaryHashtagMapping> memberDiaryHashtagMappings) {
+        return memberDiaryHashtagMappings.stream()
+                .map(mapping -> mapping.getHashtag().getName())
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    private Page<DiaryResDto> getDiaryResDtos(Page<DiaryHashtagMapping> diaryHashtagMappings) {
+        List<DiaryResDto> content = diaryHashtagMappings.getContent().stream()
+                .map(DiaryHashtagMapping::getDiary)
+                .map(DiaryResDto::from)
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(content, diaryHashtagMappings.getPageable(), diaryHashtagMappings.getTotalElements());
+    }
+
+    // 순서대로 보기
+
+
+    // 함께보기
+
+}

--- a/src/main/java/com/goormthon/rememberspring/diary/application/DiaryService.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/application/DiaryService.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -86,8 +87,18 @@ public class DiaryService {
         return new PageImpl<>(content, diaryHashtagMappings.getPageable(), diaryHashtagMappings.getTotalElements());
     }
 
-    // 순서대로 보기
+    // 순서대로보기
+    public List<HashtagDiariesResDto> orderAllDiaries(String email, int page, int size) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
 
+        Page<DiaryResDto> diaries = diaryRepository.findByMember(
+                member,
+                PageRequest.of(page, size, Sort.by(Direction.DESC, "diaryId"))
+        );
+
+        return List.of(HashtagDiariesResDto.from(diaries));
+
+    }
 
     // 함께보기
 

--- a/src/main/java/com/goormthon/rememberspring/diary/domain/entity/DiaryHashtagMapping.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/domain/entity/DiaryHashtagMapping.java
@@ -1,0 +1,39 @@
+package com.goormthon.rememberspring.diary.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiaryHashtagMapping {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "diary_hashtag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hashtag_id")
+    private Hashtag hashtag;
+
+    @Builder
+    private DiaryHashtagMapping(Diary diary, Hashtag hashtag) {
+        this.diary = diary;
+        this.hashtag = hashtag;
+    }
+}

--- a/src/main/java/com/goormthon/rememberspring/diary/domain/entity/Hashtag.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/domain/entity/Hashtag.java
@@ -1,0 +1,36 @@
+package com.goormthon.rememberspring.diary.domain.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Hashtag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "hashtag_id")
+    private Long hashtagId;
+
+    private String name;
+
+    @OneToMany(mappedBy = "hashtag", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<DiaryHashtagMapping> diaryHashtagMapping = new HashSet<>();
+
+    @Builder
+    private Hashtag(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/goormthon/rememberspring/diary/domain/repository/DiaryHashtagRepository.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/domain/repository/DiaryHashtagRepository.java
@@ -3,8 +3,20 @@ package com.goormthon.rememberspring.diary.domain.repository;
 import com.goormthon.rememberspring.diary.domain.entity.Diary;
 import com.goormthon.rememberspring.diary.domain.entity.DiaryHashtagMapping;
 import com.goormthon.rememberspring.diary.domain.entity.Hashtag;
+import com.goormthon.rememberspring.member.domain.Member;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface DiaryHashtagRepository extends JpaRepository<DiaryHashtagMapping, Long> {
     boolean existsByDiaryAndHashtag(Diary diary, Hashtag hashtag);
+
+    @Query("select d "
+            + "from DiaryHashtagMapping d "
+            + "where d.diary.member = :member")
+    List<DiaryHashtagMapping> findAllByMemberDiaryHashtag(Member member);
+
+    Page<DiaryHashtagMapping> findByDiary_MemberAndHashtag_Name(Member member, String hashtagName, Pageable pageable);
 }

--- a/src/main/java/com/goormthon/rememberspring/diary/domain/repository/DiaryHashtagRepository.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/domain/repository/DiaryHashtagRepository.java
@@ -1,0 +1,10 @@
+package com.goormthon.rememberspring.diary.domain.repository;
+
+import com.goormthon.rememberspring.diary.domain.entity.Diary;
+import com.goormthon.rememberspring.diary.domain.entity.DiaryHashtagMapping;
+import com.goormthon.rememberspring.diary.domain.entity.Hashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryHashtagRepository extends JpaRepository<DiaryHashtagMapping, Long> {
+    boolean existsByDiaryAndHashtag(Diary diary, Hashtag hashtag);
+}

--- a/src/main/java/com/goormthon/rememberspring/diary/domain/repository/DiaryRepository.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/domain/repository/DiaryRepository.java
@@ -1,9 +1,8 @@
 package com.goormthon.rememberspring.diary.domain.repository;
 
+import com.goormthon.rememberspring.diary.api.dto.response.DiaryResDto;
 import com.goormthon.rememberspring.diary.domain.entity.Diary;
 import com.goormthon.rememberspring.member.domain.Member;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,14 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
-    Optional<Diary> findByMember(Member member);
-
-    Page<Diary> findByMember(Member member, Pageable pageable);
-
-    List<Diary> findAllByMember(Member member);
-
-    @Query("SELECT d FROM Diary d WHERE d.member = :member AND YEAR(d.createAt) = :year AND MONTH(d.createAt) = :month")
-    List<Diary> findByYearAndMonth(Member member, int year, int month);
-
+    @Query("SELECT d FROM Diary d WHERE d.member = :member AND MONTH(d.createAt) = :month")
+    Page<DiaryResDto> findByMonth(Member member, int month, Pageable pageable);
 
 }

--- a/src/main/java/com/goormthon/rememberspring/diary/domain/repository/DiaryRepository.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/domain/repository/DiaryRepository.java
@@ -2,10 +2,23 @@ package com.goormthon.rememberspring.diary.domain.repository;
 
 import com.goormthon.rememberspring.diary.domain.entity.Diary;
 import com.goormthon.rememberspring.member.domain.Member;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     Optional<Diary> findByMember(Member member);
+
+    Page<Diary> findByMember(Member member, Pageable pageable);
+
+    List<Diary> findAllByMember(Member member);
+
+    @Query("SELECT d FROM Diary d WHERE d.member = :member AND YEAR(d.createAt) = :year AND MONTH(d.createAt) = :month")
+    List<Diary> findByYearAndMonth(Member member, int year, int month);
+
+
 }

--- a/src/main/java/com/goormthon/rememberspring/diary/domain/repository/DiaryRepository.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/domain/repository/DiaryRepository.java
@@ -13,4 +13,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     @Query("SELECT d FROM Diary d WHERE d.member = :member AND MONTH(d.createAt) = :month")
     Page<DiaryResDto> findByMonth(Member member, int month, Pageable pageable);
 
+    @Query("SELECT d FROM Diary d WHERE d.member = :member ")
+    Page<DiaryResDto> findByMember(Member member, Pageable pageable);
+
 }

--- a/src/main/java/com/goormthon/rememberspring/diary/domain/repository/DiaryRepository.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/domain/repository/DiaryRepository.java
@@ -1,7 +1,11 @@
 package com.goormthon.rememberspring.diary.domain.repository;
 
 import com.goormthon.rememberspring.diary.domain.entity.Diary;
+import com.goormthon.rememberspring.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+    Optional<Diary> findByMember(Member member);
 }

--- a/src/main/java/com/goormthon/rememberspring/diary/domain/repository/HashtagRepository.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/domain/repository/HashtagRepository.java
@@ -1,0 +1,9 @@
+package com.goormthon.rememberspring.diary.domain.repository;
+
+import com.goormthon.rememberspring.diary.domain.entity.Hashtag;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+    Optional<Hashtag> findByName(String tagName);
+}

--- a/src/main/java/com/goormthon/rememberspring/diary/excepion/DiaryNotFoundException.java
+++ b/src/main/java/com/goormthon/rememberspring/diary/excepion/DiaryNotFoundException.java
@@ -1,0 +1,13 @@
+package com.goormthon.rememberspring.diary.excepion;
+
+import com.goormthon.rememberspring.global.error.exception.NotFoundGroupException;
+
+public class DiaryNotFoundException extends NotFoundGroupException {
+    public DiaryNotFoundException(String message) {
+        super(message);
+    }
+
+    public DiaryNotFoundException() {
+        this("존재하지 않는 일기 입니다.");
+    }
+}

--- a/src/main/java/com/goormthon/rememberspring/image/application/ImageService.java
+++ b/src/main/java/com/goormthon/rememberspring/image/application/ImageService.java
@@ -44,6 +44,7 @@ public class ImageService {
     public List<ImageResDto> upload(String email, MultipartFile[] multipartFiles) throws IOException {
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
 
+        List<ImageResDto> responseImages = new ArrayList<>();
         int imageSequence = 1;
 
         for (MultipartFile file : multipartFiles) {
@@ -54,11 +55,13 @@ public class ImageService {
             String imgUrl = getImgUrl(filePath);
 
             storageSave(file, filePath, storage);
-            imageSave(imgUrl, imageSequence, member);
+            Image image = imageSave(imgUrl, imageSequence, member);
+            responseImages.add(ImageResDto.from(image));
+
             imageSequence++;
         }
 
-        return getImagesResDto(member);
+        return responseImages;
     }
 
     private static String getUuid() {
@@ -90,14 +93,14 @@ public class ImageService {
         storage.create(blobInfo, file.getInputStream());
     }
 
-    private void imageSave(String imgUrl, int imageSequence, Member member) {
+    private Image imageSave(String imgUrl, int imageSequence, Member member) {
         Image image = Image.builder()
                 .convertImageName(imgUrl)
                 .imageSequence(imageSequence)
                 .member(member)
                 .build();
 
-        imageRepository.save(image);
+        return imageRepository.save(image);
     }
 
     // 사용자별 이미지 전체 조회


### PR DESCRIPTION
## 요약
1. 다이어리 로직 수정
2. 이미지 업로드 반환 값 수정
3. 클래스명 변경
4. 해시태그 구현, 테이블 분리
5. 모아서보기 기능 구현
6. 순서대로보기 기능 구현

## 작업 내용
- 해시태그를 분리하여 다이어리를 불러올 때, 해시태그로 구분하여 불러옵니다.
- 월간, 해시태그별 다이어리를 불러옵니다.
- 순서대로 다이어리를 불러옵니다.

## 참고 사항

## 관련 이슈
- Close #이슈번호
